### PR TITLE
Do no publish root and docs projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ import java.nio.file.Paths
 lazy val management = project
   .in(file("."))
   .settings(unidocSettings)
+  .enablePlugins(NoPublish)
+  .disablePlugins(BintrayPlugin)
   .aggregate(`cluster-http`, docs)
 
 lazy val `cluster-http` = project
@@ -17,6 +19,7 @@ val unidocTask = sbtunidoc.Plugin.UnidocKeys.unidoc in (ProjectRef(file("."), "m
 lazy val docs = project
   .in(file("docs"))
   .enablePlugins(ParadoxPlugin, NoPublish)
+  .disablePlugins(BintrayPlugin)
   .settings(
     name := "Akka Management",
     paradoxTheme := Some(builtinParadoxTheme("generic")),
@@ -31,6 +34,7 @@ lazy val docs = project
       "scaladoc.akka.cluster.http.management.base_url" -> {
         if (isSnapshot.value) Paths.get((target in paradox in Compile).value.getPath).relativize(Paths.get(unidocTask.value.head.getPath)).toString
         else s"http://developer.lightbend.com/docs/api/akka-cluster-http-management/${version.value}"
-      }
+      },
+      "scaladoc.version" -> "2.12.0"
     )
   )

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -12,3 +12,16 @@ object NoPublish extends AutoPlugin {
     publishLocal := {}
   )
 }
+
+object Publish extends AutoPlugin {
+  import bintray.BintrayPlugin
+  import bintray.BintrayPlugin.autoImport._
+
+  override def trigger = allRequirements
+  override def requires = BintrayPlugin
+
+  override def projectSettings = Seq(
+    bintrayOrganization := Some("akka"),
+    bintrayPackage := "akka-cluster-management"
+  )
+}


### PR DESCRIPTION
Also generate 2.12 style links to scaladoc (2.11 supports 2.12 links as well, surprisingly).