### PR TITLE
Doc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.idea
+target
+
+*.orig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Akka Cluster Management
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/akka/akka?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/akka/akka)
 
 This repository contains interfaces to interact with an Akka Cluster.
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val docs = project
       "scaladoc.akka.base_url" -> s"http://doc.akka.io/api/akka/${Dependencies.AkkaVersion}",
       "scaladoc.akka.cluster.http.management.base_url" -> {
         if (isSnapshot.value) Paths.get((target in paradox in Compile).value.getPath).relativize(Paths.get(unidocTask.value.head.getPath)).toString
-        else s"http://developer.lightbend.com/docs/api/akka-cluster-http-management/${version.value}"
+        else s"http://developer.lightbend.com/docs/api/akka-cluster-management/${version.value}"
       },
       "scaladoc.version" -> "2.12.0"
     )

--- a/docs/src/main/paradox/cluster-http-management.md
+++ b/docs/src/main/paradox/cluster-http-management.md
@@ -192,8 +192,11 @@ Java
 
 ## Security
 
-> **Note:**
+@@@ note
+
 This module does not provide security by default. It's the developer's choice to add security to this API.
+
+@@@
 
 The non-secured usage of the module is as follows:
 


### PR DESCRIPTION
Noticed a broken link to `ClusterHttpManagement` from [this section](http://developer.lightbend.com/docs/akka-cluster-management/latest/cluster-http-management.html#stopping-cluster-http-management)