### PR TITLE
default hostname to InetAddress.getLocalHost.getHostAddress()

### DIFF
--- a/cluster-http/src/main/resources/reference.conf
+++ b/cluster-http/src/main/resources/reference.conf
@@ -9,6 +9,7 @@ akka.cluster.http.management {
 
   # The hostname where the HTTP Server for Http Cluster Management will be started.
   # This defines the interface to use.
+  # InetAddress.getLocalHost.getHostAddress is used if empty ("")
   hostname = "127.0.0.1"
 
   # The port where the HTTP Server for Http Cluster Management will be bound.

--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagementSettings.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagementSettings.scala
@@ -3,10 +3,18 @@
  */
 package akka.cluster.http.management
 
+import java.net.InetAddress
+
 import com.typesafe.config.Config
 
 final class ClusterHttpManagementSettings(val config: Config) {
   private val cc = config.getConfig("akka.cluster.http.management")
   val ClusterHttpManagementPort = cc.getInt("port")
-  val ClusterHttpManagementHostname = cc.getString("hostname")
+  val ClusterHttpManagementHostname = {
+    val hostname = cc.getString("hostname")
+    if (hostname == "")
+      InetAddress.getLocalHost.getHostAddress
+    else
+      hostname
+  }
 }


### PR DESCRIPTION
Default hostname to InetAddress.getLocalHost.getHostAddress() when left empty ""..

[Issue link](https://github.com/akka/akka-cluster-management/issues/11)
