### PR TITLE
Expose Oldest Member in GET /members

### DIFF
--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -23,7 +23,8 @@ final case class ClusterMember(node: String, nodeUid: String, status: String, ro
 final case class ClusterMembers(selfNode: String,
                                 members: Set[ClusterMember],
                                 unreachable: Seq[ClusterUnreachableMember],
-                                leader: Option[String])
+                                leader: Option[String],
+                                oldest: Option[String])
 final case class ClusterHttpManagementMessage(message: String)
 
 private[akka] sealed trait ClusterHttpManagementOperation
@@ -39,7 +40,7 @@ object ClusterHttpManagementOperation {
 trait ClusterHttpManagementJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val clusterUnreachableMemberFormat = jsonFormat2(ClusterUnreachableMember)
   implicit val clusterMemberFormat = jsonFormat4(ClusterMember)
-  implicit val clusterMembersFormat = jsonFormat4(ClusterMembers)
+  implicit val clusterMembersFormat = jsonFormat5(ClusterMembers)
   implicit val clusterMemberMessageFormat = jsonFormat1(ClusterHttpManagementMessage)
 }
 
@@ -61,8 +62,9 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
         }
 
         val leader = cluster.readView.leader.map(_.toString)
+        val oldest = cluster.state.members.toSeq.sorted(Member.ageOrdering).headOption.map(_.address.toString)
 
-        ClusterMembers(s"${cluster.readView.selfAddress}", members, unreachable, leader)
+        ClusterMembers(s"${cluster.readView.selfAddress}", members, unreachable, leader, oldest)
       }
     }
 

--- a/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
+++ b/cluster-http/src/main/scala/akka/cluster/http/management/ClusterHttpManagement.scala
@@ -62,7 +62,10 @@ object ClusterHttpManagementRoutes extends ClusterHttpManagementHelper {
         }
 
         val leader = cluster.readView.leader.map(_.toString)
-        val oldest = cluster.state.members.toSeq.sorted(Member.ageOrdering).headOption.map(_.address.toString)
+        val oldest = cluster.state.members
+          .toSeq.sorted(Member.ageOrdering)
+          .filter(_.status == MemberStatus.Up).headOption // we are only interested in the oldest one that is still Up
+          .map(_.address.toString)
 
         ClusterMembers(s"${cluster.readView.selfAddress}", members, unreachable, leader, oldest)
       }

--- a/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
+++ b/cluster-http/src/test/scala/akka/cluster/http/management/ClusterHttpManagementRoutesSpec.scala
@@ -5,6 +5,7 @@ package akka.cluster.http.management
 
 import akka.actor.Address
 import akka.cluster.ClusterEvent.CurrentClusterState
+import akka.cluster.MemberStatus.Joining
 import akka.cluster._
 import akka.http.scaladsl.model.{ FormData, StatusCodes }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
@@ -21,7 +22,7 @@ class ClusterHttpManagementRoutesSpec
     with ClusterHttpManagementJsonProtocol {
 
   "Http Cluster Management Routes" should {
-    "return list of members with cluster leader" when {
+    "return list of members with cluster leader and oldest" when {
       "calling GET /members" in {
         val address1 = Address("akka", "Main", "hostname.com", 3311)
         val address2 = Address("akka", "Main", "hostname2.com", 3311)
@@ -30,8 +31,8 @@ class ClusterHttpManagementRoutesSpec
         val uniqueAddress1 = UniqueAddress(address1, 1L)
         val uniqueAddress2 = UniqueAddress(address2, 2L)
 
-        val clusterMember1 = Member(uniqueAddress1, Set())
-        val clusterMember2 = Member(uniqueAddress2, Set())
+        val clusterMember1 = new Member(uniqueAddress1, 1, Joining, Set())
+        val clusterMember2 = new Member(uniqueAddress2, 2, Joining, Set())
         val currentClusterState =
           CurrentClusterState(SortedSet(clusterMember1, clusterMember2), leader = Some(address1))
 
@@ -57,7 +58,7 @@ class ClusterHttpManagementRoutesSpec
           val clusterMembers = Set(ClusterMember("akka://Main@hostname.com:3311", "1", "Joining", Set()),
             ClusterMember("akka://Main@hostname2.com:3311", "2", "Joining", Set()))
           responseAs[ClusterMembers] shouldEqual ClusterMembers(s"$address1", clusterMembers,
-            Seq(clusterUnreachableMember), Some(address1.toString))
+            Seq(clusterUnreachableMember), Some(address1.toString), Some(address1.toString))
           status == StatusCodes.OK
         }
       }


### PR DESCRIPTION
See https://github.com/akka/akka-cluster-management/issues/21

From the issue
> At eero, we've found that deploying the oldest member last makes a huge difference on stability of the akka cluster during deploys. This is because oldest hosts shard coordinators and cluster singletons.

We currently expose `oldest` in our custom healthchecks, but adding this to the `akka-cluster-management` tool will help us DRY this out (and potentially help other akka cluster users)

/cc @wbertelsen @jlynn